### PR TITLE
chore: pin Node engine to 24.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "typescript": "^5.9.3"
   },
   "engines": {
-    "node": "22.x || 24.x",
+    "node": "24.x",
     "pnpm": "^9 || ^10"
   }
 }


### PR DESCRIPTION
Vercel resolved the 22.x || 24.x range to 24.x and flagged a mismatch with the dashboard's pinned 22.x. Pin to a single version for a deterministic build.