### PR TITLE
Rebuild bbass.co on Payload CMS + Next.js 16

### DIFF
--- a/app/(frontend)/(site)/page.tsx
+++ b/app/(frontend)/(site)/page.tsx
@@ -1,13 +1,40 @@
 import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
-import { ArrowRight, Mail } from 'lucide-react'
-import { FaGithub } from 'react-icons/fa6'
+import type { ComponentType } from 'react'
+import { ArrowRight, Mail, Database } from 'lucide-react'
+import {
+  FaGithub,
+  FaLinkedin,
+  FaXTwitter,
+  FaYoutube,
+  FaDiscord,
+} from 'react-icons/fa6'
+import { HiOutlineMail } from 'react-icons/hi'
 import { JsonLd } from '@/components/structured-data'
 import { SITE_URL } from '@/lib/metadata'
 import { RoleRotator } from '@/components/role-rotator'
 import { TechStackGrid } from '@/components/agency/tech-stack-grid'
-import { roles, aboutCards, contactLinks, contactInfo } from '@/lib/data'
+import {
+  roles,
+  aboutCards,
+  contactLinks,
+  contactInfo,
+  type ContactIcon,
+} from '@/lib/data'
+
+const CONTACT_ICONS: Record<
+  ContactIcon,
+  ComponentType<{ className?: string }>
+> = {
+  email: HiOutlineMail,
+  github: FaGithub,
+  linkedin: FaLinkedin,
+  x: FaXTwitter,
+  youtube: FaYoutube,
+  discord: FaDiscord,
+  startup: Database,
+}
 
 export const metadata: Metadata = {
   title: 'Bob Bass — Engineer & Founder',
@@ -75,7 +102,7 @@ export default function HomePage() {
                   >
                     Efficient App
                   </a>
-                  . Building developer tooling at{' '}
+                  . Building the ultimate DBaaS platform at{' '}
                   <a
                     href="https://layerbase.com"
                     target="_blank"
@@ -181,29 +208,32 @@ export default function HomePage() {
             </p>
           </div>
           <div className="grid gap-4 sm:grid-cols-2">
-            {contactLinks.map((link) => (
-              <a
-                key={link.label}
-                href={link.href}
-                target={link.href.startsWith('http') ? '_blank' : undefined}
-                rel={
-                  link.href.startsWith('http')
-                    ? 'noopener noreferrer'
-                    : undefined
-                }
-                className="card-glow group flex items-center gap-4 rounded-xl border border-border/50 bg-card/50 p-4 transition-all hover:border-primary/30 hover:bg-card"
-              >
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-linear-to-br from-primary/30 to-primary/10 text-primary transition-transform group-hover:scale-110">
-                  <Mail className="h-5 w-5" />
-                </div>
-                <div className="min-w-0">
-                  <div className="text-xs text-muted-foreground">
-                    {link.label}
+            {contactLinks.map((link) => {
+              const Icon = CONTACT_ICONS[link.icon]
+              return (
+                <a
+                  key={link.label}
+                  href={link.href}
+                  target={link.href.startsWith('http') ? '_blank' : undefined}
+                  rel={
+                    link.href.startsWith('http')
+                      ? 'noopener noreferrer'
+                      : undefined
+                  }
+                  className="card-glow group flex items-center gap-4 rounded-xl border border-border/50 bg-card/50 p-4 transition-all hover:border-primary/30 hover:bg-card"
+                >
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-linear-to-br from-primary/30 to-primary/10 text-primary transition-transform group-hover:scale-110">
+                    <Icon className="h-5 w-5" />
                   </div>
-                  <div className="truncate font-medium">{link.display}</div>
-                </div>
-              </a>
-            ))}
+                  <div className="min-w-0">
+                    <div className="text-xs text-muted-foreground">
+                      {link.label}
+                    </div>
+                    <div className="truncate font-medium">{link.display}</div>
+                  </div>
+                </a>
+              )
+            })}
           </div>
           <div className="mt-10 text-center">
             <a

--- a/app/(frontend)/(site)/page.tsx
+++ b/app/(frontend)/(site)/page.tsx
@@ -72,19 +72,10 @@ export default function HomePage() {
         <div className="container mx-auto max-w-5xl">
           <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-[1.4fr_1fr] lg:gap-16">
             <div className="animate-fade-in">
-              <div className="mb-4 flex items-center gap-4">
+              <div className="mb-4">
                 <h1 className="font-display text-5xl font-bold tracking-tight md:text-6xl">
-                  Bob <span className="text-gradient">Bass</span>
+                  Bob Bass
                 </h1>
-                <a
-                  href="https://github.com/robertjbass"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="GitHub"
-                  className="text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  <FaGithub className="h-8 w-8" />
-                </a>
               </div>
 
               <div className="mb-6">

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -10,8 +10,8 @@ export async function SiteFooter() {
   const socials = [
     { href: socialLinks.github, label: 'GitHub', Icon: FaGithub },
     { href: socialLinks.linkedin, label: 'LinkedIn', Icon: FaLinkedin },
-    { href: socialLinks.twitter, label: 'Twitter', Icon: FaXTwitter },
-    { href: socialLinks.email, label: 'Email', Icon: HiOutlineMail },
+    { href: socialLinks.twitter, label: 'X', Icon: FaXTwitter },
+    { href: `mailto:${contactInfo.email}`, label: 'Email', Icon: HiOutlineMail },
   ]
 
   return (

--- a/lib/apex-domains.ts
+++ b/lib/apex-domains.ts
@@ -1,6 +1,5 @@
-// Single-domain helpers for bbass.co. The original layerbase version
-// modeled prod/dev/cloud subdomains; this site is a single apex
-// (bbass.co) plus localhost, so the cloud-subdomain logic is gone and
+// Single-domain helpers for bbass.co. This site is a single apex
+// (bbass.co) plus localhost, so there is no cloud-subdomain logic and
 // getCloudHostname always returns null.
 
 const PROD_ROOT = 'bbass.co'
@@ -38,7 +37,7 @@ export function isSameEnvironment(hostA: string, hostB: string): boolean {
 
 /**
  * No cloud dashboard subdomain on this site. Retained as a no-op so the
- * auth redirect callback (ported from layerbase) keeps a stable shape.
+ * auth redirect callback keeps a stable shape.
  */
 export function getCloudHostname(_hostname: string): string | null {
   return null

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -14,7 +14,7 @@ export const socialLinks = {
   email: 'mailto:bob@bbass.co',
   github: 'https://github.com/robertjbass',
   linkedin: 'https://linkedin.com/in/bbass9490',
-  twitter: 'https://twitter.com/bobdotjs',
+  twitter: 'https://x.com/bobdotjs',
   youtube: 'https://youtube.com/@bobDotJS',
   discord: 'https://ourpassion.dev',
   startup: 'https://layerbase.com',
@@ -59,7 +59,7 @@ export const contactLinks = [
   },
   {
     label: 'X',
-    href: 'https://twitter.com/bobdotjs',
+    href: 'https://x.com/bobdotjs',
     display: '@bobdotjs',
     icon: 'x',
   },

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -17,8 +17,17 @@ export const socialLinks = {
   twitter: 'https://twitter.com/bobdotjs',
   youtube: 'https://youtube.com/@bobDotJS',
   discord: 'https://ourpassion.dev',
-  substack: 'https://substack.com/@alternaterealms',
+  startup: 'https://layerbase.com',
 } as const
+
+export type ContactIcon =
+  | 'email'
+  | 'github'
+  | 'linkedin'
+  | 'x'
+  | 'youtube'
+  | 'discord'
+  | 'startup'
 
 // Rotating role labels in the hero.
 export const roles = [
@@ -28,36 +37,56 @@ export const roles = [
   'Full-Stack Developer',
 ] as const
 
-// Contact channels surfaced on the landing page + footer.
+// Contact channels surfaced on the landing page.
 export const contactLinks = [
-  { label: 'Email', href: 'mailto:bob@bbass.co', display: 'bob@bbass.co' },
+  {
+    label: 'Email',
+    href: 'mailto:bob@bbass.co',
+    display: 'bob@bbass.co',
+    icon: 'email',
+  },
   {
     label: 'GitHub',
     href: 'https://github.com/robertjbass',
     display: '@robertjbass',
+    icon: 'github',
   },
   {
     label: 'LinkedIn',
     href: 'https://linkedin.com/in/bbass9490',
     display: 'bbass9490',
+    icon: 'linkedin',
   },
   {
-    label: 'Twitter',
+    label: 'X',
     href: 'https://twitter.com/bobdotjs',
     display: '@bobdotjs',
+    icon: 'x',
   },
   {
     label: 'YouTube',
     href: 'https://youtube.com/@bobDotJS',
     display: '@bobDotJS',
+    icon: 'youtube',
   },
-  { label: 'Discord', href: 'https://ourpassion.dev', display: 'ourpassion.dev' },
   {
-    label: 'Substack',
-    href: 'https://substack.com/@alternaterealms',
-    display: '@alternaterealms',
+    label: 'Discord',
+    href: 'https://ourpassion.dev',
+    display: 'ourpassion.dev',
+    icon: 'discord',
   },
-] as const
+  {
+    label: 'My Startup',
+    href: 'https://layerbase.com',
+    display: 'layerbase.com',
+    icon: 'startup',
+  },
+] as const satisfies ReadonlyArray<{
+  label: string
+  href: string
+  display: string
+  icon: ContactIcon
+}>
 
 // "About" cards on the landing page.
 export const aboutCards = [
@@ -70,7 +99,7 @@ export const aboutCards = [
     emoji: '🚀',
     title: 'Founder',
     description:
-      'Ashland Development (2011 — Sold 2019), DebtOS (Pioneer 2020), Layerbase (2025)',
+      'Ashland Development (2011 — Sold 2019), DebtOS (Pioneer 2020), Layerbase (2025 — Current)',
   },
   {
     emoji: '💡',


### PR DESCRIPTION
Replaces the static portfolio with a Payload CMS (Postgres) + Next.js 16 app derived from the layerbase stack.

## Highlights
- **CMS + DB:** Payload 3 on Postgres, Vercel Blob for media
- **Auth:** GitHub-only OAuth (Auth.js v5 + Payload adapter); `bob@bbass.co` is super-admin
- **Blog:** DB-first with markdown fallback (`content/blog/*.md` renders when no DB record)
- **Landing:** new single-page design (hero + rotating roles + about cards + tech stack + contact) styled per `DESIGN.md`, seeded with personal-branding content
- **Brand:** `bbass-mark` (teal layered B) as the canonical favicon/apple-icon + wordmark
- **SEO:** Person/WebSite JSON-LD, sitemap, robots, RSS — all on `bbass.co`

## Cleanup
- Stripped layerbase's cloud/billing/teams/infra/marketing/desktop surface (~25 routes, 14 collections, scripts, migrations, docs)
- Removed unused components/hooks/libs and ~19 unused dependencies
- Single-apex (`bbass.co`) cookie/auth config; removed Loki log shipping

## Notes
- Previous static site preserved under `_legacy/`, excluded from build/lint/types
- Fresh initial Payload migration included
- Requires env: `DATABASE_URL`, `PAYLOAD_SECRET`, `AUTH_SECRET`, `AUTH_URL`, `GITHUB_CLIENT_ID/SECRET`, `BLOB_READ_WRITE_TOKEN`, `BLOB_PREFIX`